### PR TITLE
Add enable option so faker can be used in production

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,21 @@ user.set('firstName', faker.name.firstName());
 user.set('lastName', faker.name.lastName());
 ```
 
+## Environment options
+
+By default faker is included into your build for non-production
+environments. To include it in production, add this
+to your config:
+
+```js
+// config/environment.js
+if (environment === 'production') {
+  ENV['ember-faker'] = {
+    enabled: true
+  };
+}
+```
+
 ## Development
 
 ### Installation

--- a/config/environment.js
+++ b/config/environment.js
@@ -1,5 +1,6 @@
 'use strict';
 
-module.exports = function(/* environment, appConfig */) {
+module.exports = function(environment, appConfig) {
+  appConfig['ember-faker'] = appConfig['ember-faker'] || {};
   return { };
 };

--- a/index.js
+++ b/index.js
@@ -6,8 +6,9 @@ module.exports = {
 
   included: function included(app) {
     this.app = app;
+    var addonConfig = this.app.project.config(app.env)['ember-faker'];
 
-    if (app.env !== 'production') {
+    if (app.env !== 'production' || addonConfig.enabled) {
       app.import(app.bowerDirectory + '/Faker/build/build/faker.js');
       app.import('vendor/ember-faker/shim.js', {
         type: 'vendor',


### PR DESCRIPTION
Thanks for this addon! I'm using it to generate some mock data, and I've been deploying my app with all the mocks enabled to demo it to stakeholders. That's the motivation for being able to use faker in production environments.