### PR TITLE
add usePublic option to speed up builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,15 +46,18 @@ user.set('lastName', faker.name.lastName());
 
 ## Environment options
 
-By default faker is included into your build for non-production
-environments. To include it in production, add this
-to your config:
-
 ```js
 // ember-cli-build.js
 let app = new EmberApp(defaults, {
   'ember-faker': {
-    enabled: EmberApp.env === 'production'
+    // By default faker is included into your build for non-production
+    // environments. To include it in production, add this
+    // to your config:
+    enabled: EmberApp.env === 'production',
+
+    // place in /assets/faker.js instead of /assets/vendor.js
+    // this can speed up your build because it avoids sourcemaps/concat
+    usePublic: true
   }
 });
 ```

--- a/index.js
+++ b/index.js
@@ -6,11 +6,27 @@ module.exports = {
   options: {
     nodeAssets: {
       faker() {
-        return {
+        let options = {
           enabled: this._shouldInclude(),
-          import: ['build/build/faker.js']
+        };
+
+        if (this._shouldUsePublic()) {
+          options.public = {
+            srcDir: 'build/build',
+            include: ['faker.js']
+          };
+        } else {
+          options.import = ['build/build/faker.js'];
         }
+
+        return options;
       }
+    }
+  },
+
+  contentFor(type, { rootURL }) {
+    if (type === 'body' && this._shouldUsePublic()) {
+      return `<script src="${rootURL}assets/faker.js"></script>`;
     }
   },
 
@@ -44,5 +60,11 @@ module.exports = {
     let addonConfig = this._getAddonConfig();
 
     return addonConfig.enabled;
+  },
+
+  _shouldUsePublic() {
+    let addonConfig = this._getAddonConfig();
+
+    return addonConfig.usePublic;
   }
 };

--- a/node-tests/import-test.js
+++ b/node-tests/import-test.js
@@ -83,4 +83,27 @@ describe('import', function() {
     });
   });
 
+  it('uses vendor tree by default', function() {
+    const addon = new EmberAddon({
+      'ember-faker': {
+        usePublic: false
+      }
+    });
+
+    expect(addon._scriptOutputFiles['/assets/vendor.js']).to.include(
+      'vendor/faker/build/build/faker.js'
+    );
+  });
+
+  it('can use public tree instead of vendor tree', function() {
+    const addon = new EmberAddon({
+      'ember-faker': {
+        usePublic: true
+      }
+    });
+
+    expect(addon._scriptOutputFiles['/assets/vendor.js']).to.not.include(
+      'vendor/faker/build/build/faker.js'
+    );
+  });
 });


### PR DESCRIPTION
This trick shaved over a second off our builds. Treating large files as-is helps alleviate the final concat/sourcemap step.

before:
<img width="1076" alt="screen shot 2018-10-09 at 16 05 18" src="https://user-images.githubusercontent.com/602423/47440523-41021a80-d7a6-11e8-9407-4f3db049d37a.png">
after:
<img width="1077" alt="screen shot 2018-10-09 at 16 05 30" src="https://user-images.githubusercontent.com/602423/47440538-495a5580-d7a6-11e8-8296-d91639e00d80.png">

Similar to https://github.com/rynam0/ember-swagger-ui/pull/47